### PR TITLE
Allow composer plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,11 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "composer/installers": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   },
   "scripts": {
     "lint": "find ./orphan-command.php ./inc/ -type f -name '*.php' -print0 | xargs -0 -L 1 -P 4 -- php -l",


### PR DESCRIPTION
previously merged PR allows for composer v2 but needed an `allow-plugins` section to pass CI