### PR TITLE
Remove the dependency on `wp-cli/wp-cli`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
   },
   "require": {
     "php": ">=7.2",
-    "composer/installers": "^1.0 || ^2.0",
-    "wp-cli/wp-cli": "^2.5"
+    "composer/installers": "^1.0 || ^2.0"
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",


### PR DESCRIPTION
Fixes #4 