### PR TITLE
Fix post deletion for PHP 8

### DIFF
--- a/inc/Orphan_Post_Command.php
+++ b/inc/Orphan_Post_Command.php
@@ -138,7 +138,7 @@ class Orphan_Post_Command extends Orphan_Command {
 	 */
 	protected function delete_orphan( int $id ): bool {
 
-		return wp_delete_post( $id, true );
+		return (bool) wp_delete_post( $id, true );
 	}
 
 	/**


### PR DESCRIPTION
When merged, this PR fixes #9.

The `wp_post_delete` function in WordPress returns `WP_Post|false|null`, whereas the internal `delete_orphan` command is expected to return `bool` only. This PR fixes the PHP Fatal Error.