### PR TITLE
Throw error for multisite command if not multisite

### DIFF
--- a/orphan-command.php
+++ b/orphan-command.php
@@ -31,7 +31,13 @@ if ( is_readable( $wpcli_orphan_autoloader ) ) {
 }
 unset( $wpcli_orphan_autoloader );
 
-WP_CLI::add_command( 'orphan blog meta', HumanMade\OrphanCommand\Orphan_Blog_Meta_Command::class );
+WP_CLI::add_command( 'orphan blog meta', HumanMade\OrphanCommand\Orphan_Blog_Meta_Command::class, [
+        'before_invoke' => function () {
+                if ( ! is_multisite() ) {
+                        WP_CLI::error( 'This is not a multisite installation.' );
+                }
+        },
+] );
 WP_CLI::add_command( 'orphan comment', HumanMade\OrphanCommand\Orphan_Comment_Command::class );
 WP_CLI::add_command( 'orphan comment meta', HumanMade\OrphanCommand\Orphan_Comment_Meta_Command::class );
 WP_CLI::add_command( 'orphan post', HumanMade\OrphanCommand\Orphan_Post_Command::class );


### PR DESCRIPTION
When merged, this PR fixes #7.

This PR adds a check that is running before invoking a `wp orphan blog` command to throw an error if the WordPress context is not a multisite installation.
This is in line with core WP CLI commands such as [`wp network meta`](https://github.com/wp-cli/entity-command/blob/4f390246f935a29188df813dd7b9dd476358c374/entity-command.php#L19-L29).